### PR TITLE
[artf38904]: Removed LANL-csdreg dependency from stonix.spec

### DIFF
--- a/src/stonix.spec
+++ b/src/stonix.spec
@@ -29,7 +29,7 @@ License: GPL v. 2.0
 Group: System administration tools
 Source0: %{name}-%{version}.tgz
 BuildRoot: %{_builddir}/%{name}-%{version}-%{release}-root
-Requires: python, LANL-csdreg, curl
+Requires: python, curl
 BuildArch: noarch
 
 %description
@@ -91,9 +91,6 @@ rm -rf $RPM_BUILD_ROOT
 %dir %attr(0755,root,root) /usr/share/man/man8
 
 %post
-# Register the installation of this product
-
-/usr/local/sbin/csdreg -p STONIX-%{version}-install
 
 %postun
 


### PR DESCRIPTION
This should not be in the public spec file.
